### PR TITLE
Fix: Removed propType requirement for clientSecret

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const basePropTypes = {
   oauthClient: PropTypes.shape({
     options: PropTypes.shape({
       clientId: PropTypes.string.isRequired,
-      clientSecret: PropTypes.string.isRequired,
+      clientSecret: PropTypes.string,
       redirectUri: PropTypes.string.isRequired,
       authorizationUri: PropTypes.string.isRequired,
       accessTokenUri: PropTypes.string.isRequired,


### PR DESCRIPTION
Removes the failed prop type error when not passing a client secret.
Client secrets are not required by OAuth2 spec and are not recommended for Single Page Apps and other situations where the secret cannot be protected.

Fixes #4